### PR TITLE
Fix: Navigation links accessibility

### DIFF
--- a/Sources/FuturedKit/NavigationLinks.swift
+++ b/Sources/FuturedKit/NavigationLinks.swift
@@ -58,7 +58,7 @@ struct NavigationLinksWrapper<Links: View>: ViewModifier {
     }
 
     func body(content: Content) -> some View {
-        if #available(iOS 14.0, *) {
+        if #available(macOS 11.0, iOS 14.0, *) {
             ZStack {
                 navigationLinks
                     .accessibilityHidden(true)

--- a/Sources/FuturedKit/NavigationLinks.swift
+++ b/Sources/FuturedKit/NavigationLinks.swift
@@ -61,9 +61,9 @@ struct NavigationLinksWrapper<Links: View>: ViewModifier {
         if #available(iOS 14.0, *) {
             ZStack {
                 navigationLinks
+                    .accessibilityHidden(true)
                 content
             }
-            .accessibilityHidden(true)
         } else {
             ZStack {
                 navigationLinks

--- a/Sources/FuturedKit/NavigationLinks.swift
+++ b/Sources/FuturedKit/NavigationLinks.swift
@@ -58,9 +58,17 @@ struct NavigationLinksWrapper<Links: View>: ViewModifier {
     }
 
     func body(content: Content) -> some View {
-        ZStack {
-            navigationLinks
-            content
+        if #available(iOS 14.0, *) {
+            ZStack {
+                navigationLinks
+                content
+            }
+            .accessibilityHidden(true)
+        } else {
+            ZStack {
+                navigationLinks
+                content
+            }
         }
     }
 }


### PR DESCRIPTION
Ahoj, všiml jsem si takového nešvaru. Navigation linky se nám dostávají do VoiceOver čtečky.

https://user-images.githubusercontent.com/26277065/194013216-bf2649f8-d4c4-458a-afe7-b6787bf01637.mov



