### PR TITLE
Remove CollectionConcurrencyKit from package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -8,15 +8,6 @@
         "revision" : "fe58851b967301ec5c391a2c34979b676b854f89",
         "version" : "1.0.0"
       }
-    },
-    {
-      "identity" : "collectionconcurrencykit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit",
-      "state" : {
-        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
-        "version" : "0.2.0"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -17,15 +17,13 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/mkj-is/BindingKit", from: "1.0.0"),
-        .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit", from: "0.1.0")
+        .package(url: "https://github.com/mkj-is/BindingKit", from: "1.0.0")
     ],
     targets: [
         .target(
             name: "FuturedKit",
             dependencies: [
-                .product(name: "BindingKit", package: "BindingKit"),
-                .product(name: "CollectionConcurrencyKit", package: "CollectionConcurrencyKit")
+                .product(name: "BindingKit", package: "BindingKit")
             ]
         ),
         .testTarget(

--- a/Sources/FuturedKit/ImagePicker/GalleryImagePicker/GalleryImagePicker.swift
+++ b/Sources/FuturedKit/ImagePicker/GalleryImagePicker/GalleryImagePicker.swift
@@ -1,7 +1,6 @@
 #if canImport(UIKit)
 
 import BindingKit
-import CollectionConcurrencyKit
 import SwiftUI
 import PhotosUI
 
@@ -55,8 +54,9 @@ public struct GalleryImagePicker: View {
     private func handlePickerResult(_ results: [PHPickerResult]) {
         presentationMode.wrappedValue.dismiss()
         Task {
-            selection = try await results.map(\.itemProvider).concurrentMap { item in
-                try await item.loadImage()
+            selection = []
+            for item in results.map(\.itemProvider) {
+                selection.append(try await item.loadImage())
             }
         }
     }


### PR DESCRIPTION
Ahoj, přemýšlím jestli v FuturedKitu potřebujeme package `CollectionConcurrencyKit`, když se jedná prakticky o jednu funkci. Zkusil jsem navrhnout alternativu. Netestoval jsem, ale myslím si, že by to mělo mít stejný výsledek. 

Co vy na to?