### PR TITLE
Mark NavigationStackFlow init as @MainActor

### DIFF
--- a/Sources/FuturedArchitecture/Architecture/NavigationStackFlow.swift
+++ b/Sources/FuturedArchitecture/Architecture/NavigationStackFlow.swift
@@ -10,7 +10,7 @@ public struct NavigationStackFlow<Coordinator: NavigationStackCoordinator, Conte
     ///   - coordinator: The instance of the coordinator used as the model and retained as the ``SwiftUI.StateObject``
     ///   - content: The root view of this navigation stack. The ``navigationDestination(for:destination:)`` modifier
     ///   is applied to this content.
-    public init(coordinator: @autoclosure @escaping () -> Coordinator, content: @escaping () -> Content) {
+    public init(coordinator: @autoclosure @escaping () -> Coordinator, content: @MainActor @escaping () -> Content) {
         self._coordinator = StateObject(wrappedValue: coordinator())
         self.content = content
     }


### PR DESCRIPTION
Mark init of view content as `@MainActor` for NavigationStackFlow.

With this change the "root view" of coordinators will be able to access the properties of coordinators it self which is marked as `@MainActor` in protocol. Without this change it's emitting warning which will be turned into an error in Swift 6.