### PR TITLE
Add support of Height detents and animation

### DIFF
--- a/Sources/FuturedArchitecture/Architecture/ModalCoverModel.swift
+++ b/Sources/FuturedArchitecture/Architecture/ModalCoverModel.swift
@@ -12,14 +12,17 @@ import Foundation
 public enum SheetDetent: Hashable {
     case medium
     case large
+    case height
     case fraction(CGFloat)
 
-    func detent() -> PresentationDetent {
+    func detent(size: CGSize) -> PresentationDetent {
         switch self {
         case .medium:
             return .medium
         case .large:
             return .large
+        case .height:
+            return .height(size.height)
         case let .fraction(fraction):
             return .fraction(fraction)
         }


### PR DESCRIPTION
Add support of PresentationDetent.height for NavigationStack displayed as modal sheet cover. 

This approach will recalculate height of currently presented view which is part of NavigationStack in modal sheet cover.

Issue: When navigating from higher view to lower one the presentation detents is set correctly but the content of that particular scene has a weird animation. @jmarek41 @samoilyk @mikolasstuchlik do you have any idea how to get rid of that unwanted animation ? 🤔 (The issue is visible in last part of the video starting from 16s)

Other PresentationDetents (.large, .medium, .fraction) works without any issue and it's already merged to main so it can be part of a new version of FuturedKit w/o support of PresentationDetent.height. The code for those presentation detents is more simple ([see PR](https://github.com/futuredapp/FuturedKit/pull/38/files)).

https://github.com/user-attachments/assets/26f92d59-4bdf-4279-9386-e713ce0a1ed0

