### PR TITLE
Fix: Prevent overriding child view presentation detents

### DIFF
--- a/Sources/FuturedArchitecture/Architecture/NavigationStackFlow.swift
+++ b/Sources/FuturedArchitecture/Architecture/NavigationStackFlow.swift
@@ -28,7 +28,7 @@ public struct NavigationStackFlow<Coordinator: NavigationStackCoordinator, Conte
         NavigationStack(path: $coordinator.path) {
             content().navigationDestination(for: Coordinator.Destination.self, destination: coordinator.scene(for:))
         }
-        .presentationDetents(navigationDetents ?? [])
+        .modifier(OptionalPresentationDetentsModifier(detents: navigationDetents))
         .sheet(item: sheetBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
         #if !os(macOS)
         .fullScreenCover(item: fullscreenCoverBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
@@ -52,4 +52,18 @@ public struct NavigationStackFlow<Coordinator: NavigationStackCoordinator, Conte
         }
     }
     #endif
+}
+
+/// A view modifier that conditionally applies presentation detents only when they are non-nil.
+/// This prevents overriding child view detents with an empty set when no detents are specified.
+private struct OptionalPresentationDetentsModifier: ViewModifier {
+    let detents: Set<PresentationDetent>?
+
+    func body(content: Content) -> some View {
+        if let detents {
+            content.presentationDetents(detents)
+        } else {
+            content
+        }
+    }
 }


### PR DESCRIPTION
When NavigationStackFlow is initialized without the 'detents' parameter, it was applying .presentationDetents([]) (empty set) which incorrectly overrode presentation detents defined in child views.

This change introduces OptionalPresentationDetentsModifier that only applies presentation detents when they are explicitly provided (non-nil), allowing child views to define their own detents without interference.

Issue:
- Child views using .presentationDetents() were being overridden
- Sheets would open at maximum detent instead of specified heights
- Close buttons and custom detent behaviors were broken

Solution:
- Replace .presentationDetents(navigationDetents ?? []) with conditional modifier
- Only apply detents when explicitly provided via init parameter
- Preserve backward compatibility for existing code