### PR TITLE
Fix false-positive DataCache emission tests

### DIFF
--- a/Tests/FuturedKitTests/DataCacheTests.swift
+++ b/Tests/FuturedKitTests/DataCacheTests.swift
@@ -27,15 +27,7 @@ struct DataCacheTests {
 
         // Verify initial value is not emitted
         let skipStream = await cache.values(skipInitial: true)
-        await confirmation("initial value is not emitted", expectedCount: 0) { shouldNotEmit in
-            let task = Task {
-                for await _ in skipStream {
-                    shouldNotEmit()
-                }
-            }
-            try? await Task.sleep(for: .milliseconds(50))
-            task.cancel()
-        }
+        await assertNoEmission(on: skipStream) {}
 
         // Verify first update is emitted
         let stream = await cache.values(skipInitial: true)
@@ -51,15 +43,8 @@ struct DataCacheTests {
         let cache = DataCache(value: 1)
 
         let stream = await cache.values(skipInitial: true)
-        await confirmation("same value does not emit", expectedCount: 0) { shouldNotEmit in
-            let task = Task {
-                for await _ in stream {
-                    shouldNotEmit()
-                }
-            }
+        await assertNoEmission(on: stream) {
             await cache.update(with: 1)
-            try? await Task.sleep(for: .milliseconds(50))
-            task.cancel()
         }
     }
 
@@ -84,15 +69,8 @@ struct DataCacheTests {
         let cache = DataCache(value: Model(count: 0, items: [1], optionalItems: nil))
 
         let stream = await cache.values(skipInitial: true)
-        await confirmation("empty populate does not emit", expectedCount: 0) { shouldNotEmit in
-            let task = Task {
-                for await _ in stream {
-                    shouldNotEmit()
-                }
-            }
+        await assertNoEmission(on: stream) {
             await cache.populate(\.items, with: [Int]())
-            try? await Task.sleep(for: .milliseconds(50))
-            task.cancel()
         }
     }
 
@@ -220,15 +198,8 @@ struct DataCacheTests {
         let cache = DataCache(value: Model(count: 5, items: [], optionalItems: nil))
 
         let stream = await cache.values(skipInitial: true)
-        await confirmation("same keyPath value does not emit", expectedCount: 0) { shouldNotEmit in
-            let task = Task {
-                for await _ in stream {
-                    shouldNotEmit()
-                }
-            }
+        await assertNoEmission(on: stream) {
             await cache.update(\.count, with: 5)
-            try? await Task.sleep(for: .milliseconds(50))
-            task.cancel()
         }
     }
 
@@ -237,15 +208,8 @@ struct DataCacheTests {
         let cache = DataCache(value: Model(count: 0, items: [1, 2, 3], optionalItems: nil))
 
         let stream = await cache.values(skipInitial: true)
-        await confirmation("unchanged populate does not emit", expectedCount: 0) { shouldNotEmit in
-            let task = Task {
-                for await _ in stream {
-                    shouldNotEmit()
-                }
-            }
+        await assertNoEmission(on: stream) {
             await cache.populate(\.items, with: [1, 2, 3])
-            try? await Task.sleep(for: .milliseconds(50))
-            task.cancel()
         }
     }
 
@@ -254,15 +218,8 @@ struct DataCacheTests {
         let cache = DataCache(value: Model(count: 0, items: [], optionalItems: [1, 2]))
 
         let stream = await cache.values(skipInitial: true)
-        await confirmation("unchanged optional populate does not emit", expectedCount: 0) { shouldNotEmit in
-            let task = Task {
-                for await _ in stream {
-                    shouldNotEmit()
-                }
-            }
+        await assertNoEmission(on: stream) {
             await cache.populate(\.optionalItems, with: [1, 2])
-            try? await Task.sleep(for: .milliseconds(50))
-            task.cancel()
         }
     }
 
@@ -281,5 +238,24 @@ struct DataCacheTests {
         #expect(result.contains(4))
         #expect(result.contains(5))
         #expect(result.count == 5)
+    }
+
+    // MARK: - Helper methods
+
+    /// Asserts that no values are emitted on the given stream while `action` executes.
+    private func assertNoEmission<T: Sendable>(
+        on stream: AsyncStream<T>,
+        during action: () async -> Void
+    ) async {
+        await confirmation(expectedCount: 0) { shouldNotEmit in
+            let task = Task {
+                for await _ in stream {
+                    shouldNotEmit()
+                }
+            }
+            await action()
+            try? await Task.sleep(for: .milliseconds(50))
+            task.cancel()
+        }
     }
 }

--- a/Tests/FuturedKitTests/DataCacheTests.swift
+++ b/Tests/FuturedKitTests/DataCacheTests.swift
@@ -21,10 +21,23 @@ struct DataCacheTests {
         #expect(first == 1)
     }
 
-    @Test("values(skipInitial: true) first yielded element is the first update")
+    @Test("values(skipInitial: true) does not yield the initial value, first yield is the first update")
     func valuesSkipInitialYieldsOnFirstChange() async throws {
         let cache = DataCache(value: 1)
 
+        // Verify initial value is not emitted
+        let skipStream = await cache.values(skipInitial: true)
+        await confirmation("initial value is not emitted", expectedCount: 0) { shouldNotEmit in
+            let task = Task {
+                for await _ in skipStream {
+                    shouldNotEmit()
+                }
+            }
+            try? await Task.sleep(for: .milliseconds(50))
+            task.cancel()
+        }
+
+        // Verify first update is emitted
         let stream = await cache.values(skipInitial: true)
         var iterator = stream.makeAsyncIterator()
         await cache.update(with: 2)
@@ -33,24 +46,21 @@ struct DataCacheTests {
         #expect(first == 2)
     }
 
-    @Test("update(with:) does not emit when value is unchanged (next emission is the later different value)")
+    @Test("update(with:) does not emit when value is unchanged")
     func updateDoesNotEmitOnSameValue() async throws {
         let cache = DataCache(value: 1)
 
-        let stream = await cache.values(skipInitial: false)
-        var iterator = stream.makeAsyncIterator()
-
-        // Consume initial
-        _ = await iterator.next()
-
-        // Same value should not emit
-        await cache.update(with: 1)
-
-        // Different value should emit next
-        await cache.update(with: 2)
-
-        let next = await iterator.next()
-        #expect(next == 2) // If the same-value update emitted, next would be 1 (or not 2).
+        let stream = await cache.values(skipInitial: true)
+        await confirmation("same value does not emit", expectedCount: 0) { shouldNotEmit in
+            let task = Task {
+                for await _ in stream {
+                    shouldNotEmit()
+                }
+            }
+            await cache.update(with: 1)
+            try? await Task.sleep(for: .milliseconds(50))
+            task.cancel()
+        }
     }
 
     @Test("update(keyPath:with:) emits when the property changes")
@@ -73,22 +83,17 @@ struct DataCacheTests {
     func populateEmptyDoesNotEmit() async throws {
         let cache = DataCache(value: Model(count: 0, items: [1], optionalItems: nil))
 
-        let stream = await cache.values(skipInitial: false)
-        var iterator = stream.makeAsyncIterator()
-
-        // Consume initial
-        _ = await iterator.next()
-
-        // Empty should not emit…
-        await cache.populate(\.items, with: [Int]())
-
-        // …but a real populate should.
-        await cache.populate(\.items, with: [2])
-
-        let next = await iterator.next()
-        let unwrapped = try #require(next)
-        #expect(unwrapped.items.contains(1) == true)
-        #expect(unwrapped.items.contains(2) == true)
+        let stream = await cache.values(skipInitial: true)
+        await confirmation("empty populate does not emit", expectedCount: 0) { shouldNotEmit in
+            let task = Task {
+                for await _ in stream {
+                    shouldNotEmit()
+                }
+            }
+            await cache.populate(\.items, with: [Int]())
+            try? await Task.sleep(for: .milliseconds(50))
+            task.cancel()
+        }
     }
 
     @Test("populate(collection) emits and appends new elements")
@@ -214,63 +219,51 @@ struct DataCacheTests {
     func updateKeyPathDoesNotEmitOnSameValue() async throws {
         let cache = DataCache(value: Model(count: 5, items: [], optionalItems: nil))
 
-        let stream = await cache.values(skipInitial: false)
-        var iterator = stream.makeAsyncIterator()
-
-        // Consume initial
-        _ = await iterator.next()
-
-        // Same value should not emit
-        await cache.update(\.count, with: 5)
-
-        // Different value should emit next
-        await cache.update(\.count, with: 10)
-
-        let next = await iterator.next()
-        let unwrapped = try #require(next)
-        #expect(unwrapped.count == 10)
+        let stream = await cache.values(skipInitial: true)
+        await confirmation("same keyPath value does not emit", expectedCount: 0) { shouldNotEmit in
+            let task = Task {
+                for await _ in stream {
+                    shouldNotEmit()
+                }
+            }
+            await cache.update(\.count, with: 5)
+            try? await Task.sleep(for: .milliseconds(50))
+            task.cancel()
+        }
     }
 
     @Test("populate does not emit when merged result is identical to current value")
     func populateDoesNotEmitWhenUnchanged() async throws {
         let cache = DataCache(value: Model(count: 0, items: [1, 2, 3], optionalItems: nil))
 
-        let stream = await cache.values(skipInitial: false)
-        var iterator = stream.makeAsyncIterator()
-
-        // Consume initial
-        _ = await iterator.next()
-
-        // Populating with the same items in the same order produces identical result — should not emit.
-        await cache.populate(\.items, with: [1, 2, 3])
-
-        // Adding a genuinely new item should emit.
-        await cache.populate(\.items, with: [4])
-
-        let next = await iterator.next()
-        let unwrapped = try #require(next)
-        #expect(unwrapped.items == [1, 2, 3, 4])
+        let stream = await cache.values(skipInitial: true)
+        await confirmation("unchanged populate does not emit", expectedCount: 0) { shouldNotEmit in
+            let task = Task {
+                for await _ in stream {
+                    shouldNotEmit()
+                }
+            }
+            await cache.populate(\.items, with: [1, 2, 3])
+            try? await Task.sleep(for: .milliseconds(50))
+            task.cancel()
+        }
     }
 
     @Test("populate(optional) does not emit when merged result is identical to current value")
     func populateOptionalDoesNotEmitWhenUnchanged() async throws {
         let cache = DataCache(value: Model(count: 0, items: [], optionalItems: [1, 2]))
 
-        let stream = await cache.values(skipInitial: false)
-        var iterator = stream.makeAsyncIterator()
-
-        // Consume initial
-        _ = await iterator.next()
-
-        // Populating with the same items in the same order produces identical result — should not emit.
-        await cache.populate(\.optionalItems, with: [1, 2])
-
-        // Adding a genuinely new item should emit.
-        await cache.populate(\.optionalItems, with: [3])
-
-        let next = await iterator.next()
-        let unwrapped = try #require(next)
-        #expect(unwrapped.optionalItems == [1, 2, 3])
+        let stream = await cache.values(skipInitial: true)
+        await confirmation("unchanged optional populate does not emit", expectedCount: 0) { shouldNotEmit in
+            let task = Task {
+                for await _ in stream {
+                    shouldNotEmit()
+                }
+            }
+            await cache.populate(\.optionalItems, with: [1, 2])
+            try? await Task.sleep(for: .milliseconds(50))
+            task.cancel()
+        }
     }
 
     @Test("populate merges and updates existing elements")


### PR DESCRIPTION
## Summary

Six "does not emit" tests in `DataCacheTests` were false positives — they passed even if the equality guards in `DataCache` were removed. The root cause: `AsyncStream` uses `.bufferingNewest(1)`, which silently drops the unwanted emission before the iterator consumes it, making the follow-up assertion meaningless.

Replaced the flawed pattern with `confirmation(expectedCount: 0)` from Swift Testing, which explicitly asserts that zero emissions occur during a given action. Extracted a reusable `assertNoEmission(on:during:)` helper to keep the tests DRY.

## Changes

- **6 tests fixed**: `valuesSkipInitialYieldsOnFirstChange`, `updateDoesNotEmitOnSameValue`, `populateEmptyDoesNotEmit`, `updateKeyPathDoesNotEmitOnSameValue`, `populateDoesNotEmitWhenUnchanged`, `populateOptionalDoesNotEmitWhenUnchanged`
- **New helper**: `assertNoEmission(on:during:)` — reusable negative-emission assertion
- Net reduction: **46 additions, 77 deletions**

### Diagram
<details>
<summary>View diagram</summary>

```mermaid
flowchart TD
    subgraph before["Before (Flawed)"]
        B1[update with same value] --> B2[update with different value]
        B2 --> B3["iterator.next() == different?"]
        B3 -->|PASS| B4["bufferingNewest(1) silently\ndrops same-value emission\n— test passes regardless"]
    end

    subgraph after["After (Correct)"]
        A1["confirmation(expectedCount: 0)"] --> A2["Task: for await → shouldNotEmit()"]
        A1 --> A3[action — same-value update]
        A3 --> A4["sleep(50ms) + cancel"]
        A4 --> A5["PASS only if 0 emissions"]
    end

    before -.->|replaced by| after
```

</details>