### PR TITLE
Add TabContentFlow for iOS 18+ Tab API

### DIFF
--- a/Sources/FuturedArchitecture/Architecture/ModalCoverModifier.swift
+++ b/Sources/FuturedArchitecture/Architecture/ModalCoverModifier.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Adds `.sheet` and (on non-macOS platforms) `.fullScreenCover` presentation
+/// driven by a ``Coordinator``'s ``Coordinator/modalCover`` state.
+///
+/// Use this modifier in any flow container view (e.g. ``NavigationStackFlow``,
+/// ``TabViewFlow``, ``TabContentFlow``) to keep modal presentation behaviour consistent.
+struct ModalCoverModifier<C: Coordinator>: ViewModifier {
+    var coordinator: C
+
+    private var sheetBinding: Binding<C.Destination?> {
+        .init {
+            coordinator.modalCover?.style == .sheet ? coordinator.modalCover?.destination : nil
+        } set: { destination in
+            coordinator.modalCover = destination.map { .init(destination: $0, style: .sheet) }
+        }
+    }
+
+    #if os(macOS)
+    func body(content: Content) -> some View {
+        content
+            .sheet(item: sheetBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
+    }
+    #else
+    private var fullscreenCoverBinding: Binding<C.Destination?> {
+        .init {
+            coordinator.modalCover?.style == .fullscreenCover ? coordinator.modalCover?.destination : nil
+        } set: { destination in
+            coordinator.modalCover = destination.map { .init(destination: $0, style: .fullscreenCover) }
+        }
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(item: sheetBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
+            .fullScreenCover(item: fullscreenCoverBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
+    }
+    #endif
+}

--- a/Sources/FuturedArchitecture/Architecture/NavigationStackFlow.swift
+++ b/Sources/FuturedArchitecture/Architecture/NavigationStackFlow.swift
@@ -29,29 +29,8 @@ public struct NavigationStackFlow<Coordinator: NavigationStackCoordinator, Conte
             content().navigationDestination(for: Coordinator.Destination.self, destination: coordinator.scene(for:))
         }
         .modifier(OptionalPresentationDetentsModifier(detents: navigationDetents))
-        .sheet(item: sheetBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
-        #if !os(macOS)
-        .fullScreenCover(item: fullscreenCoverBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
-        #endif
+        .modifier(ModalCoverModifier(coordinator: coordinator))
     }
-
-    private var sheetBinding: Binding<Coordinator.Destination?> {
-        .init {
-            coordinator.modalCover?.style == .sheet ? coordinator.modalCover?.destination : nil
-        } set: { destination in
-            coordinator.modalCover = destination.map { .init(destination: $0, style: .sheet) }
-        }
-    }
-
-    #if !os(macOS)
-    private var fullscreenCoverBinding: Binding<Coordinator.Destination?> {
-        .init {
-            coordinator.modalCover?.style == .fullscreenCover ? coordinator.modalCover?.destination : nil
-        } set: { destination in
-            coordinator.modalCover = destination.map { .init(destination: $0, style: .fullscreenCover) }
-        }
-    }
-    #endif
 }
 
 /// A view modifier that conditionally applies presentation detents only when they are non-nil.

--- a/Sources/FuturedArchitecture/Architecture/TabViewFlow.swift
+++ b/Sources/FuturedArchitecture/Architecture/TabViewFlow.swift
@@ -2,6 +2,9 @@ import SwiftUI
 
 /// The `TabViewFlow` encapsulates the ``SwiftUI.TabView`` and binds it to the
 /// variables and callbacks of the ``TabCoordinator`` which it retains as a ``SwiftUI.State``.
+///
+/// Uses the legacy `.tabItem` + `.tag` pattern. For iOS 18+ projects that need
+/// ``SwiftUI.Tab`` features (e.g. `Tab(role: .search)`), use ``TabContentFlow`` instead.
 /// - Experiment: This API is in preview and subject to change.
 public struct TabViewFlow<Coordinator: TabCoordinator, Content: View>: View {
     @State private var coordinator: Coordinator
@@ -16,24 +19,58 @@ public struct TabViewFlow<Coordinator: TabCoordinator, Content: View>: View {
         self.content = content
     }
 
-    #if os(macOS)
     public var body: some View {
         TabView(selection: $coordinator.selectedTab) {
             content()
         }
-        .sheet(item: sheetBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
+        .modifier(ModalCoverModifier(coordinator: coordinator))
     }
-    #else
-    public var body: some View {
-        TabView(selection: $coordinator.selectedTab) {
-            content()
-        }
-        .sheet(item: sheetBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
-        .fullScreenCover(item: fullscreenCoverBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
-    }
-    #endif
+}
 
-    private var sheetBinding: Binding<Coordinator.Destination?> {
+// MARK: - TabContentFlow (iOS 18+)
+
+/// A variant of ``TabViewFlow`` that accepts ``SwiftUI.TabContent`` instead of `View`,
+/// enabling the iOS 18+ ``SwiftUI.Tab`` API with features like `Tab(role: .search)`.
+///
+/// Use this instead of ``TabViewFlow`` when you need `Tab(role:)`, customizable tab
+/// placement, or other iOS 18+ tab features.
+///
+/// Usage:
+/// ```swift
+/// TabContentFlow(coordinator: instance) {
+///     Tab("Home", systemImage: "house", value: Tab.home) { ... }
+///     Tab(value: Tab.search, role: .search) { ... }
+/// }
+/// ```
+/// - Experiment: This API is in preview and subject to change.
+@available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, *)
+public struct TabContentFlow<Coordinator: TabCoordinator, Content: TabContent<Coordinator.Tab>>: View {
+    @State private var coordinator: Coordinator
+    @TabContentBuilder<Coordinator.Tab> private let content: () -> Content
+
+    /// - Parameters:
+    ///   - coordinator: The instance of the coordinator used as the model and retained as ``SwiftUI.State``
+    ///   - content: The definition of tabs using the ``SwiftUI.Tab`` API.
+    public init(coordinator: Coordinator, @TabContentBuilder<Coordinator.Tab> content: @MainActor @escaping () -> Content) {
+        self._coordinator = State(wrappedValue: coordinator)
+        self.content = content
+    }
+
+    public var body: some View {
+        TabView(selection: $coordinator.selectedTab) {
+            content()
+        }
+        .modifier(ModalCoverModifier(coordinator: coordinator))
+    }
+}
+
+// MARK: - Shared Modal Presentation
+
+/// Shared modifier that adds sheet and full-screen cover presentation to any coordinator-backed view.
+struct ModalCoverModifier<C: Coordinator>: ViewModifier {
+    var coordinator: C
+
+    private var sheetBinding: Binding<C.Destination?> {
         .init {
             coordinator.modalCover?.style == .sheet ? coordinator.modalCover?.destination : nil
         } set: { destination in
@@ -41,13 +78,24 @@ public struct TabViewFlow<Coordinator: TabCoordinator, Content: View>: View {
         }
     }
 
-    #if !os(macOS)
-    private var fullscreenCoverBinding: Binding<Coordinator.Destination?> {
+    #if os(macOS)
+    func body(content: Content) -> some View {
+        content
+            .sheet(item: sheetBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
+    }
+    #else
+    private var fullscreenCoverBinding: Binding<C.Destination?> {
         .init {
             coordinator.modalCover?.style == .fullscreenCover ? coordinator.modalCover?.destination : nil
         } set: { destination in
             coordinator.modalCover = destination.map { .init(destination: $0, style: .fullscreenCover) }
         }
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .sheet(item: sheetBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
+            .fullScreenCover(item: fullscreenCoverBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
     }
     #endif
 }

--- a/Sources/FuturedArchitecture/Architecture/TabViewFlow.swift
+++ b/Sources/FuturedArchitecture/Architecture/TabViewFlow.swift
@@ -63,39 +63,3 @@ public struct TabContentFlow<Coordinator: TabCoordinator, Content: TabContent<Co
         .modifier(ModalCoverModifier(coordinator: coordinator))
     }
 }
-
-// MARK: - Shared Modal Presentation
-
-/// Shared modifier that adds sheet and full-screen cover presentation to any coordinator-backed view.
-struct ModalCoverModifier<C: Coordinator>: ViewModifier {
-    var coordinator: C
-
-    private var sheetBinding: Binding<C.Destination?> {
-        .init {
-            coordinator.modalCover?.style == .sheet ? coordinator.modalCover?.destination : nil
-        } set: { destination in
-            coordinator.modalCover = destination.map { .init(destination: $0, style: .sheet) }
-        }
-    }
-
-    #if os(macOS)
-    func body(content: Content) -> some View {
-        content
-            .sheet(item: sheetBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
-    }
-    #else
-    private var fullscreenCoverBinding: Binding<C.Destination?> {
-        .init {
-            coordinator.modalCover?.style == .fullscreenCover ? coordinator.modalCover?.destination : nil
-        } set: { destination in
-            coordinator.modalCover = destination.map { .init(destination: $0, style: .fullscreenCover) }
-        }
-    }
-
-    func body(content: Content) -> some View {
-        content
-            .sheet(item: sheetBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
-            .fullScreenCover(item: fullscreenCoverBinding, onDismiss: coordinator.onModalDismiss, content: coordinator.scene(for:))
-    }
-    #endif
-}

--- a/Sources/FuturedArchitecture/Architecture/TabViewFlow.swift
+++ b/Sources/FuturedArchitecture/Architecture/TabViewFlow.swift
@@ -6,6 +6,10 @@ import SwiftUI
 /// Uses the legacy `.tabItem` + `.tag` pattern. For iOS 18+ projects that need
 /// ``SwiftUI.Tab`` features (e.g. `Tab(role: .search)`), use ``TabContentFlow`` instead.
 /// - Experiment: This API is in preview and subject to change.
+@available(iOS, deprecated: 18.0, message: "Use TabContentFlow for the iOS 18+ Tab API.")
+@available(macOS, deprecated: 15.0, message: "Use TabContentFlow for the macOS 15+ Tab API.")
+@available(tvOS, deprecated: 18.0, message: "Use TabContentFlow for the tvOS 18+ Tab API.")
+@available(watchOS, deprecated: 11.0, message: "Use TabContentFlow for the watchOS 11+ Tab API.")
 public struct TabViewFlow<Coordinator: TabCoordinator, Content: View>: View {
     @State private var coordinator: Coordinator
     @ViewBuilder private let content: () -> Content


### PR DESCRIPTION
## Summary
- Přidává `TabContentFlow` — varianta `TabViewFlow` pro iOS 18+ `Tab` API (`@TabContentBuilder`)
- Umožňuje použití `Tab(role: .search)` a dalších iOS 18+ tab features v coordinator patternu
- Extrahuje sdílenou modal logiku do `ModalCoverModifier` (snížení duplikace)
- Non-breaking: stávající `TabViewFlow` zůstává pro zpětnou kompatibilitu