### PR TITLE
Add xcconfig templates and ConfigKey protocol

### DIFF
--- a/Sources/FuturedHelpers/Helpers/ConfigKey.swift
+++ b/Sources/FuturedHelpers/Helpers/ConfigKey.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Protocol for configuration keys that provides default implementation for retrieving values from Info.plist
+/// with automatic Base64 decoding support
+public protocol ConfigKey: RawRepresentable where RawValue == String {
+    /// Default implementation that retrieves and decodes values from Info.plist
+    var value: String { get throws }
+}
+
+public extension ConfigKey {
+    /// Default implementation that reads from Info.plist and handles Base64 decoding
+    var value: String {
+        get throws {
+            guard let rawValue = Bundle.main.object(forInfoDictionaryKey: rawValue) as? String else {
+                throw ConfigKeyError.valueNotFound(key: rawValue)
+            }
+
+            // Try to decode as Base64, fallback to original value if not encoded
+            guard let data = Data(base64Encoded: rawValue),
+                  let decodedString = String(data: data, encoding: .utf8) else {
+                // Not valid Base64, return original value
+                return rawValue
+            }
+            return decodedString
+        }
+    }
+}
+
+/// Error type for configuration key handling
+public enum ConfigKeyError: LocalizedError {
+    case valueNotFound(key: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .valueNotFound(key):
+            "Value for \"\(key)\" was not found in .xcconfig file. Check if the value with this key is imported from GitHub secrets to .xcconfig file and whether it is specified in Info.plist."
+        }
+    }
+}

--- a/Templates/SwiftUI App.xctemplate/Beta.xcconfig
+++ b/Templates/SwiftUI App.xctemplate/Beta.xcconfig
@@ -6,3 +6,12 @@
 
 // TODO: Add Swift compilation flags
 // OTHER_SWIFT_FLAGS = $(inherited)
+
+// NOTE: Each key added here must also be added to Info.plist as:
+//   <key>KEY_NAME</key>
+//   <string>$(KEY_NAME)</string>
+// Then access it in code using the ConfigKey protocol from FuturedHelpers:
+//   enum AppConfigKey: String, ConfigKey {
+//       case apiKey = "API_KEY"
+//   }
+//   let value = try AppConfigKey.apiKey.value

--- a/Templates/SwiftUI App.xctemplate/Beta.xcconfig
+++ b/Templates/SwiftUI App.xctemplate/Beta.xcconfig
@@ -1,11 +1,6 @@
 // Beta configuration
 
-// TODO: Add API configuration
-// API_KEY =
-// API_BASE_URL =
-
-// TODO: Add Swift compilation flags
-// OTHER_SWIFT_FLAGS = $(inherited)
+// Do not add any key-value pairs here, they should be injected via CI
 
 // NOTE: Each key added here must also be added to Info.plist as:
 //   <key>KEY_NAME</key>

--- a/Templates/SwiftUI App.xctemplate/Beta.xcconfig
+++ b/Templates/SwiftUI App.xctemplate/Beta.xcconfig
@@ -1,0 +1,8 @@
+// Beta configuration
+
+// TODO: Add API configuration
+// API_KEY =
+// API_BASE_URL =
+
+// TODO: Add Swift compilation flags
+// OTHER_SWIFT_FLAGS = $(inherited)

--- a/Templates/SwiftUI App.xctemplate/Debug.xcconfig
+++ b/Templates/SwiftUI App.xctemplate/Debug.xcconfig
@@ -1,0 +1,9 @@
+// Debug configuration
+#include? "Local.xcconfig"
+
+// TODO: Add API configuration
+// API_KEY =
+// API_BASE_URL =
+
+// TODO: Add Swift compilation flags
+// OTHER_SWIFT_FLAGS = $(inherited) -D LOG_ENABLED

--- a/Templates/SwiftUI App.xctemplate/Debug.xcconfig
+++ b/Templates/SwiftUI App.xctemplate/Debug.xcconfig
@@ -2,13 +2,13 @@
 #include? "Local.xcconfig"
 
 // TODO: Add API configuration
-// API_KEY =
+// API_KEY = <specify in Local.xcconfig so the key will not be part of git history>
 // API_BASE_URL =
 
 // TODO: Add Swift compilation flags
 // OTHER_SWIFT_FLAGS = $(inherited) -D LOG_ENABLED
 
-// NOTE: Each key added here must also be added to Info.plist as:
+// IMPORTANT: Each key added must also be added to Info.plist as:
 //   <key>KEY_NAME</key>
 //   <string>$(KEY_NAME)</string>
 // Then access it in code using the ConfigKey protocol from FuturedHelpers:

--- a/Templates/SwiftUI App.xctemplate/Debug.xcconfig
+++ b/Templates/SwiftUI App.xctemplate/Debug.xcconfig
@@ -7,3 +7,12 @@
 
 // TODO: Add Swift compilation flags
 // OTHER_SWIFT_FLAGS = $(inherited) -D LOG_ENABLED
+
+// NOTE: Each key added here must also be added to Info.plist as:
+//   <key>KEY_NAME</key>
+//   <string>$(KEY_NAME)</string>
+// Then access it in code using the ConfigKey protocol from FuturedHelpers:
+//   enum AppConfigKey: String, ConfigKey {
+//       case apiKey = "API_KEY"
+//   }
+//   let value = try AppConfigKey.apiKey.value

--- a/Templates/SwiftUI App.xctemplate/Local.xcconfig
+++ b/Templates/SwiftUI App.xctemplate/Local.xcconfig
@@ -3,3 +3,12 @@
 
 // API_KEY =
 // OTHER_SWIFT_FLAGS = $(inherited) -D LOG_ENABLED
+
+// NOTE: Each key added here must also be added to Info.plist as:
+//   <key>KEY_NAME</key>
+//   <string>$(KEY_NAME)</string>
+// Then access it in code using the ConfigKey protocol from FuturedHelpers:
+//   enum AppConfigKey: String, ConfigKey {
+//       case apiKey = "API_KEY"
+//   }
+//   let value = try AppConfigKey.apiKey.value

--- a/Templates/SwiftUI App.xctemplate/Local.xcconfig
+++ b/Templates/SwiftUI App.xctemplate/Local.xcconfig
@@ -1,0 +1,5 @@
+// Local configuration (not tracked by git)
+// Add your local overrides and secrets here
+
+// API_KEY =
+// OTHER_SWIFT_FLAGS = $(inherited) -D LOG_ENABLED

--- a/Templates/SwiftUI App.xctemplate/Release.xcconfig
+++ b/Templates/SwiftUI App.xctemplate/Release.xcconfig
@@ -1,17 +1,3 @@
 // Release configuration
 
-// TODO: Add API configuration
-// API_KEY =
-// API_BASE_URL =
-
-// TODO: Add Swift compilation flags
-// OTHER_SWIFT_FLAGS = $(inherited)
-
-// NOTE: Each key added here must also be added to Info.plist as:
-//   <key>KEY_NAME</key>
-//   <string>$(KEY_NAME)</string>
-// Then access it in code using the ConfigKey protocol from FuturedHelpers:
-//   enum AppConfigKey: String, ConfigKey {
-//       case apiKey = "API_KEY"
-//   }
-//   let value = try AppConfigKey.apiKey.value
+// Do not add any key-value pairs here, they should be injected via CI

--- a/Templates/SwiftUI App.xctemplate/Release.xcconfig
+++ b/Templates/SwiftUI App.xctemplate/Release.xcconfig
@@ -6,3 +6,12 @@
 
 // TODO: Add Swift compilation flags
 // OTHER_SWIFT_FLAGS = $(inherited)
+
+// NOTE: Each key added here must also be added to Info.plist as:
+//   <key>KEY_NAME</key>
+//   <string>$(KEY_NAME)</string>
+// Then access it in code using the ConfigKey protocol from FuturedHelpers:
+//   enum AppConfigKey: String, ConfigKey {
+//       case apiKey = "API_KEY"
+//   }
+//   let value = try AppConfigKey.apiKey.value

--- a/Templates/SwiftUI App.xctemplate/Release.xcconfig
+++ b/Templates/SwiftUI App.xctemplate/Release.xcconfig
@@ -1,0 +1,8 @@
+// Release configuration
+
+// TODO: Add API configuration
+// API_KEY =
+// API_BASE_URL =
+
+// TODO: Add Swift compilation flags
+// OTHER_SWIFT_FLAGS = $(inherited)

--- a/Templates/SwiftUI App.xctemplate/TemplateInfo.plist
+++ b/Templates/SwiftUI App.xctemplate/TemplateInfo.plist
@@ -59,8 +59,15 @@
     <dict>
         <key>Configurations</key>
         <dict>
+            <key>Debug</key>
+            <dict>
+                <key>baseConfigurationReferenceRelativePath</key>
+                <string>Configuration/Debug.xcconfig</string>
+            </dict>
             <key>Beta</key>
             <dict>
+                <key>baseConfigurationReferenceRelativePath</key>
+                <string>Configuration/Beta.xcconfig</string>
                 <key>ENABLE_NS_ASSERTIONS</key>
                 <string>NO</string>
                 <key>MTL_ENABLE_DEBUG_INFO</key>
@@ -73,6 +80,11 @@
                 <string>-O</string>
                 <key>VALIDATE_PRODUCT</key>
                 <string>YES</string>
+            </dict>
+            <key>Release</key>
+            <dict>
+                <key>baseConfigurationReferenceRelativePath</key>
+                <string>Configuration/Release.xcconfig</string>
             </dict>
         </dict>
     </dict>
@@ -122,6 +134,10 @@
     <key>Nodes</key>
     <array>
         <string>Resources/Assets.xcassets</string>
+        <string>Configuration/Debug.xcconfig</string>
+        <string>Configuration/Beta.xcconfig</string>
+        <string>Configuration/Release.xcconfig</string>
+        <string>Configuration/Local.xcconfig</string>
         <string>___PACKAGENAME:identifier___App.swift</string>
         <string>AppCoordinator.swift</string>
         <string>AppDelegate.swift</string>
@@ -157,6 +173,43 @@
             </array>
             <key>SortOrder</key>
             <integer>100</integer>
+        </dict>
+
+        <key>Configuration/Debug.xcconfig</key>
+        <dict>
+            <key>Path</key>
+            <string>Debug.xcconfig</string>
+            <key>Group</key>
+            <string>Configuration</string>
+            <key>SortOrder</key>
+            <integer>98</integer>
+        </dict>
+        <key>Configuration/Beta.xcconfig</key>
+        <dict>
+            <key>Path</key>
+            <string>Beta.xcconfig</string>
+            <key>Group</key>
+            <string>Configuration</string>
+            <key>SortOrder</key>
+            <integer>98</integer>
+        </dict>
+        <key>Configuration/Release.xcconfig</key>
+        <dict>
+            <key>Path</key>
+            <string>Release.xcconfig</string>
+            <key>Group</key>
+            <string>Configuration</string>
+            <key>SortOrder</key>
+            <integer>98</integer>
+        </dict>
+        <key>Configuration/Local.xcconfig</key>
+        <dict>
+            <key>Path</key>
+            <string>Local.xcconfig</string>
+            <key>Group</key>
+            <string>Configuration</string>
+            <key>SortOrder</key>
+            <integer>98</integer>
         </dict>
 
         <key>___PACKAGENAME:identifier___App.swift</key>


### PR DESCRIPTION
## Summary
Adds xcconfig-based configuration management to the SwiftUI App template with per-environment config files (Debug, Beta, Release, Local) and a new `ConfigKey` protocol in FuturedHelpers for type-safe Info.plist value retrieval with automatic Base64 decoding.

## Changes
- `ConfigKey` protocol with default implementation that reads from `Bundle.main` Info.plist and auto-decodes Base64 values
- `ConfigKeyError` with descriptive error messages guiding developers to check xcconfig/Info.plist wiring
- Debug config includes `Local.xcconfig` via `#include?` for git-ignored local secrets
- Beta and Release configs are empty by design — values injected via CI
- `TemplateInfo.plist` updated to wire all xcconfig files into the Xcode project template under a `Configuration` group

### Diagram
<details>
<summary>View diagram</summary>

```mermaid
flowchart TD
    subgraph xcconfig["xcconfig files"]
        Local["Local.xcconfig\n(git-ignored secrets)"]
        Debug["Debug.xcconfig\n(dev settings)"]
        Beta["Beta.xcconfig\n(CI injected)"]
        Release["Release.xcconfig\n(CI injected)"]
    end

    Local -->|"#include?"| Debug
    Debug --> Build["Build Settings"]
    Beta --> Build
    Release --> Build
    Build --> Plist["Info.plist\n$(KEY_NAME)"]
    Plist --> ConfigKey["ConfigKey protocol\n(auto Base64 decode)"]
    ConfigKey --> App["App code\ntry AppConfigKey.apiKey.value"]
```

</details>

## Notes
- `Local.xcconfig` should be added to `.gitignore` in consumer projects to keep secrets out of version control