### PR TITLE
Add SwiftLint build phase to SwiftUI App template

### DIFF
--- a/Templates/SwiftUI App.xctemplate/App.swift
+++ b/Templates/SwiftUI App.xctemplate/App.swift
@@ -7,6 +7,9 @@ import SwiftUI
 // swiftlint:disable:next line_length
 #warning("Add UILaunchScreen (dictionary) to Info.plist. Without it, iOS runs the app in legacy compatibility mode and the UI does not fill the full screen on modern devices.")
 
+// swiftlint:disable:next line_length
+#warning("Drag the 'SwiftLint' build phase above 'Compile Sources' in the target's Build Phases. Xcode templates can only append phases, so SwiftLint --fix corrections currently apply only to the next build instead of the current one.")
+
 @main
 struct ___PACKAGENAME:identifier___App: App {
     @UIApplicationDelegateAdaptor private var appDelegate: AppDelegate

--- a/Templates/SwiftUI App.xctemplate/TemplateInfo.plist
+++ b/Templates/SwiftUI App.xctemplate/TemplateInfo.plist
@@ -124,6 +124,26 @@
                     <string>___VARIABLE_bundleIdentifierPrefix:bundleIdentifier___.___PACKAGENAMEASRFC1034IDENTIFIER___.beta</string>
                 </dict>
             </dict>
+            <key>BuildPhases</key>
+            <array>
+                <dict>
+                    <key>Class</key>
+                    <string>ShellScript</string>
+                    <key>Name</key>
+                    <string>SwiftLint</string>
+                    <key>ShellPath</key>
+                    <string>/bin/sh</string>
+                    <key>ShellScript</key>
+                    <string>export PATH="$PATH:/opt/homebrew/bin"
+if which swiftlint &gt; /dev/null; then
+    swiftlint --fix --quiet
+    swiftlint
+else
+    echo "warning: SwiftLint not installed — install with: brew install swiftlint"
+fi
+</string>
+                </dict>
+            </array>
         </dict>
     </array>
 

--- a/Templates/SwiftUI App.xctemplate/TemplateInfo.plist
+++ b/Templates/SwiftUI App.xctemplate/TemplateInfo.plist
@@ -111,6 +111,8 @@
                 <string>Manual</string>
                 <key>SWIFT_VERSION</key>
                 <string>6</string>
+                <key>ENABLE_USER_SCRIPT_SANDBOXING</key>
+                <string>NO</string>
             </dict>
             <key>Configurations</key>
             <dict>
@@ -142,6 +144,18 @@ else
     echo "warning: SwiftLint not installed — install with: brew install swiftlint"
 fi
 </string>
+                </dict>
+                <dict>
+                    <key>Class</key>
+                    <string>Sources</string>
+                </dict>
+                <dict>
+                    <key>Class</key>
+                    <string>Frameworks</string>
+                </dict>
+                <dict>
+                    <key>Class</key>
+                    <string>Resources</string>
                 </dict>
             </array>
         </dict>

--- a/Templates/SwiftUI App.xctemplate/TemplateInfo.plist
+++ b/Templates/SwiftUI App.xctemplate/TemplateInfo.plist
@@ -145,18 +145,6 @@ else
 fi
 </string>
                 </dict>
-                <dict>
-                    <key>Class</key>
-                    <string>Sources</string>
-                </dict>
-                <dict>
-                    <key>Class</key>
-                    <string>Frameworks</string>
-                </dict>
-                <dict>
-                    <key>Class</key>
-                    <string>Resources</string>
-                </dict>
             </array>
         </dict>
     </array>


### PR DESCRIPTION
## Summary

Adds a **SwiftLint** Run Script build phase to the SwiftUI App Xcode project template. Generated projects autocorrect on every build and surface remaining warnings in Xcode's issue navigator — no manual install of the phase itself needed after project creation.

> Stacked on #64. PR base will retarget to `main` automatically once #64 merges.

## Flow

```mermaid
flowchart LR
    A[Build starts] --> B[Compile Sources]
    B --> C[Link Frameworks]
    C --> D[Copy Resources]
    D --> E[SwiftLint phase]
    E --> F{swiftlint on PATH?}
    F -- yes --> G[swiftlint --fix --quiet]
    G --> H[swiftlint]
    H --> I[Warnings in Xcode]
    F -- no --> J[Build-log warning:<br/>'brew install swiftlint']
```

## Key Changes

- **`Templates/SwiftUI App.xctemplate/TemplateInfo.plist`**
  - New `BuildPhases` array on the app target with a single `ShellScript` phase named `SwiftLint`.
  - `ENABLE_USER_SCRIPT_SANDBOXING = NO` added to `SharedSettings` — Xcode 15+ sandboxes script phases by default, which blocks SwiftLint from reading project files (`Sandbox: swiftlint deny file-read-data …`).
- **`Templates/SwiftUI App.xctemplate/App.swift`** — new `#warning` instructing the developer to drag the SwiftLint phase above `Compile Sources`.
- Script exports `/opt/homebrew/bin` for Apple Silicon, runs `swiftlint --fix --quiet` then `swiftlint`. Graceful fallback emits a build-log warning when SwiftLint isn't installed.

## Known Limitation — Phase Position

Xcode project templates can only **append** custom phases to a target — there is no documented key (`InsertBefore`, `Position`, `ReplaceBuildPhases`, …) to insert before phases inherited from `com.apple.dt.unit.applicationBase`. Confirmed empirically (declaring `Sources`/`Frameworks`/`Resources` in the child array creates *duplicate* empty phases instead of replacing the inherited ones) and via research of public Xcode templates on disk and community projects (surfstudio, GoodRequest) — all of them rely on the same after-Sources position.

Consequence: as generated, the SwiftLint phase runs **after** Compile Sources, so `--fix` corrections apply to the *next* build. The new `#warning` in `App.swift` tells the developer to drag the phase above Compile Sources once — the reorder persists in `project.pbxproj`.

## Out of Scope

- Shipping a default `.swiftlint.yml` inside the template — left to the developer.
- Build phase for the **Scene** file template — file templates can't inject build phases.
- Programmatic post-creation reordering of `project.pbxproj` — would require shipping a Ruby/Python script with the template.

## Test Plan

- [x] Generate a project from the SwiftUI App template with SwiftLint installed; confirm the `SwiftLint` build phase appears on the target (one, not duplicated)
- [x] Introduce a deliberate style violation; confirm it appears as an Xcode warning
- [x] Manually drag the SwiftLint phase above Compile Sources, introduce an autocorrectable violation; confirm `--fix` corrects it on the same build
- [ ] Generate on a machine **without** SwiftLint; confirm the build succeeds with the install-hint warning
- [x] Confirm no `Sandbox: swiftlint deny …` errors in the build log
- [x] Confirm the `#warning` about reordering appears in the issue navigator on first build