### PR TITLE
Add AttributedString.emphasizing helper to FuturedHelpers

### DIFF
--- a/Sources/FuturedHelpers/Helpers/AttributedString+Emphasis.swift
+++ b/Sources/FuturedHelpers/Helpers/AttributedString+Emphasis.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+extension AttributeContainer {
+    /// A "strongly emphasized" (bold) attribute container backed by `inlinePresentationIntent`.
+    ///
+    /// Emphasis is expressed as an *intent* rather than a concrete font, so SwiftUI `Text` and
+    /// UIKit both render it bold relative to the surrounding text and it stays correct across
+    /// Dynamic Type sizes and font families. This is the default styling applied by
+    /// ``Swift/AttributedString/emphasizing(_:in:with:)``.
+    public static var stronglyEmphasized: AttributeContainer {
+        var container = AttributeContainer()
+        container.inlinePresentationIntent = .stronglyEmphasized
+        return container
+    }
+}
+
+extension AttributedString {
+    /// Builds an attributed string from `template` and applies `attributes` to the first
+    /// occurrence of `emphasized`.
+    ///
+    /// The common "localized sentence with one emphasized run" pattern — e.g. bolding the email
+    /// in *"An account with **you@example.com** already exists."*. When `emphasized` is empty or
+    /// not found, `template` is returned with no attributes applied.
+    ///
+    /// - Parameters:
+    ///   - emphasized: The substring to style. Only its first occurrence is affected.
+    ///   - template: The full text, typically a localized string.
+    ///   - attributes: Attributes merged onto the matched range. Defaults to
+    ///     ``Foundation/AttributeContainer/stronglyEmphasized`` (bold).
+    /// - Returns: The attributed `template` with `attributes` applied to the first match.
+    public static func emphasizing(
+        _ emphasized: some StringProtocol,
+        in template: String,
+        with attributes: AttributeContainer = .stronglyEmphasized
+    ) -> AttributedString {
+        emphasizing(emphasized, in: template) { attributed, range in
+            attributed[range].mergeAttributes(attributes)
+        }
+    }
+
+    private static func emphasizing(
+        _ emphasized: some StringProtocol,
+        in template: String,
+        applying: (inout AttributedString, Range<AttributedString.Index>) -> Void
+    ) -> AttributedString {
+        var attributed = AttributedString(template)
+        guard !emphasized.isEmpty, let range = attributed.range(of: emphasized) else {
+            return attributed
+        }
+        applying(&attributed, range)
+        return attributed
+    }
+}
+
+#if canImport(UIKit)
+extension AttributedString {
+    /// Builds an attributed string from `template` and applies `style` to the first occurrence
+    /// of `emphasized`.
+    ///
+    /// A `TextStyle`-driven counterpart to ``Swift/AttributedString/emphasizing(_:in:with:)`` so
+    /// the emphasized run can pull font, kerning, and decoration straight from the design system
+    /// instead of a hand-built ``Foundation/AttributeContainer``. Applies the same attributes as
+    /// ``Swift/AttributedStringProtocol/stylize(with:)``.
+    ///
+    /// - Parameters:
+    ///   - emphasized: The substring to style. Only its first occurrence is affected.
+    ///   - template: The full text, typically a localized string.
+    ///   - style: The text style applied to the matched range.
+    /// - Returns: The attributed `template` with `style` applied to the first match.
+    public static func emphasizing(
+        _ emphasized: some StringProtocol,
+        in template: String,
+        style: TextStyle
+    ) -> AttributedString {
+        emphasizing(emphasized, in: template) { attributed, range in
+            attributed[range].stylize(with: style)
+        }
+    }
+}
+#endif

--- a/Tests/FuturedKitTests/AttributedStringEmphasisTests.swift
+++ b/Tests/FuturedKitTests/AttributedStringEmphasisTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+@testable import FuturedHelpers
+import Testing
+
+@Suite("AttributedString emphasis")
+struct AttributedStringEmphasisTests {
+    private func emphasizedRuns(in attributed: AttributedString) -> [String] {
+        attributed.runs
+            .filter { $0.inlinePresentationIntent == .stronglyEmphasized }
+            .map { String(attributed[$0.range].characters) }
+    }
+
+    @Test("stronglyEmphasized container carries the bold intent")
+    func stronglyEmphasizedContainer() {
+        let container = AttributeContainer.stronglyEmphasized
+        #expect(container.inlinePresentationIntent == .stronglyEmphasized)
+    }
+
+    @Test("default emphasizes the matched substring in bold")
+    func defaultBoldsSubstring() {
+        let result = AttributedString.emphasizing("you@example.com", in: "Account you@example.com exists.")
+        #expect(emphasizedRuns(in: result) == ["you@example.com"])
+    }
+
+    @Test("full plain text is preserved")
+    func preservesPlainText() {
+        let template = "Account you@example.com exists."
+        let result = AttributedString.emphasizing("you@example.com", in: template)
+        #expect(String(result.characters) == template)
+    }
+
+    @Test("only the first occurrence is emphasized")
+    func firstOccurrenceOnly() {
+        let result = AttributedString.emphasizing("aa", in: "aa bb aa")
+        #expect(emphasizedRuns(in: result) == ["aa"])
+    }
+
+    @Test("missing substring returns the template unstyled")
+    func missingSubstring() {
+        let template = "No match here."
+        let result = AttributedString.emphasizing("zzz", in: template)
+        #expect(String(result.characters) == template)
+        #expect(emphasizedRuns(in: result).isEmpty)
+    }
+
+    @Test("empty substring returns the template unstyled")
+    func emptySubstring() {
+        let template = "Nothing to emphasize."
+        let result = AttributedString.emphasizing("", in: template)
+        #expect(String(result.characters) == template)
+        #expect(emphasizedRuns(in: result).isEmpty)
+    }
+
+    @Test("a custom container is merged onto the matched range")
+    func customContainer() {
+        var container = AttributeContainer()
+        container.inlinePresentationIntent = .emphasized
+        let result = AttributedString.emphasizing("world", in: "hello world", with: container)
+
+        let italicRuns = result.runs
+            .filter { $0.inlinePresentationIntent == .emphasized }
+            .map { String(result[$0.range].characters) }
+        #expect(italicRuns == ["world"])
+        #expect(emphasizedRuns(in: result).isEmpty)
+    }
+}
+
+#if canImport(UIKit)
+@Suite("AttributedString emphasis with TextStyle")
+struct AttributedStringEmphasisTextStyleTests {
+    private static var emphasis: TextStyle {
+        TextStyle(
+            fontType: .system(weight: .bold),
+            size: 16,
+            lineHeight: 20
+        )
+    }
+
+    @Test("TextStyle overload applies the style font to the matched range")
+    func appliesStyleFont() {
+        let result = AttributedString.emphasizing("world", in: "hello world", style: Self.emphasis)
+
+        let styledText = result.runs
+            .filter { $0.font != nil }
+            .map { String(result[$0.range].characters) }
+        #expect(styledText == ["world"])
+    }
+
+    @Test("TextStyle overload leaves the template unstyled when the substring is missing")
+    func missingSubstringLeavesUnstyled() {
+        let template = "hello there"
+        let result = AttributedString.emphasizing("world", in: template, style: Self.emphasis)
+        #expect(String(result.characters) == template)
+        #expect(result.runs.allSatisfy { $0.font == nil })
+    }
+}
+#endif


### PR DESCRIPTION
Shared helper for the recurring "localized template + emphasize one substring" AttributedString pattern (bolding an email in a sentence, etc.), which several apps have each reimplemented locally.

- **`AttributeContainer.stronglyEmphasized`** — bold default via `inlinePresentationIntent` (an intent, not a pinned font, so it renders bold in SwiftUI `Text` + UIKit and survives Dynamic Type).
- **`AttributedString.emphasizing(_:in:with:)`** — applies an `AttributeContainer` (default `.stronglyEmphasized`) to the first occurrence of the substring; returns the template unchanged when the substring is empty or absent.
- **`AttributedString.emphasizing(_:in:style:)`** — `TextStyle` overload built on the existing `stylize(with:)`, `#if canImport(UIKit)`-gated to match `TextStyle`.

Tests cover both overloads (macOS for the container API, iOS for the `TextStyle` path). Verified with `swift test` and `xcodebuild build-for-testing -destination 'generic/platform=iOS Simulator'`; SwiftLint clean.